### PR TITLE
Exclude `macOS-latest-ghc-{8.10,9.0}` from build matrix.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,21 @@ jobs:
           - macOS-latest
           - windows-latest
         cabal:
-          - 3.10.2.0
+          - '3.10'
         ghc:
-          - 8.10.7
-          - 9.0.2
-          - 9.2.8
-          - 9.4.8
-          - 9.6.4
-          - 9.8.1
+          - '8.10'
+          - '9.0'
+          - '9.2'
+          - '9.4'
+          - '9.6'
+          - '9.8'
+        exclude:
+          # TODO: https://github.com/haskell-actions/setup/issues/77
+          # To work around the above issue, we exclude the following versions:
+          - os: macOS-latest
+            ghc: '8.10'
+          - os: macOS-latest
+            ghc: '9.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,7 +115,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.8.1'
+            && matrix.ghc == '9.8'
         run: >
           mv ${{ env.cabal-build-dir }}/build/*/*/*/doc/html/* gh-pages
 
@@ -118,7 +125,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.8.1'
+            && matrix.ghc == '9.8'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages


### PR DESCRIPTION
As a temporary workaround for:
https://github.com/haskell-actions/setup/issues/77